### PR TITLE
Adding new fields to YAML object to use a different user when doing

### DIFF
--- a/jasper_server/jasper.py
+++ b/jasper_server/jasper.py
@@ -54,7 +54,7 @@ class report_jasper(report_int):
         try:
             return Report(self.name, cr, uid, ids, data, context).execute()
         except JasperException, e:
-            raise except_osv(e.title, e.message)
+            raise except_osv(e.name, e.value)
 
 report_jasper('report.print.jasper.server')
 

--- a/jasper_server/jasper_yaml_object.py
+++ b/jasper_server/jasper_yaml_object.py
@@ -33,5 +33,7 @@ class jasper_yaml_object(osv.osv):
         'offset': fields.integer('Offset'),
         'limit': fields.integer('Limit'),
         'order': fields.char('Order', size=128),
+        'yaml_context': fields.char('Context',),
+        'yaml_user_id': fields.many2one('res.users', string='User'),
         'fields': fields.text('Fields in YAML'),
     }

--- a/jasper_server/jasper_yaml_object.py
+++ b/jasper_server/jasper_yaml_object.py
@@ -33,7 +33,7 @@ class jasper_yaml_object(osv.osv):
         'offset': fields.integer('Offset'),
         'limit': fields.integer('Limit'),
         'order': fields.char('Order', size=128),
-        'yaml_context': fields.char('Context',),
-        'yaml_user_id': fields.many2one('res.users', string='User'),
+        'context': fields.char('Context',),
+        'user_id': fields.many2one('res.users', string='User'),
         'fields': fields.text('Fields in YAML'),
     }

--- a/jasper_server/jasper_yaml_object_view.xml
+++ b/jasper_server/jasper_yaml_object_view.xml
@@ -26,6 +26,8 @@
                             <group>
                                 <field name="limit" />
                                 <field name="order" />
+                                <field name="yaml_user_id" />
+                                <field name="yaml_context" />
                             </group>
                         </group>
                         

--- a/jasper_server/jasper_yaml_object_view.xml
+++ b/jasper_server/jasper_yaml_object_view.xml
@@ -26,8 +26,8 @@
                             <group>
                                 <field name="limit" />
                                 <field name="order" />
-                                <field name="yaml_user_id" />
-                                <field name="yaml_context" />
+                                <field name="user_id" />
+                                <field name="context" />
                             </group>
                         </group>
                         

--- a/jasper_server/jasperlib.py
+++ b/jasper_server/jasperlib.py
@@ -271,9 +271,9 @@ if __name__ == '__main__':
         js = Jasper(tjs_host, int(tjs_port), tjs_user, tjs_pass)
         js.auth()
     except ServerNotFound:
-        print 'Error, server not found %s %d' % (js.host, js.port)
+        raise ServerNotFound('Error, server not found %s %d' % (js.host, js.port))
     except AuthError:
-        print 'Error, Authentification failed for %s/%s' % (js.user, js.pwd)
+        raise AuthError('Error, Authentification failed for %s/%s' % (js.user, js.pwd))
 
     params = {
         'OERP_COMPANY_ID': 1,
@@ -288,9 +288,9 @@ if __name__ == '__main__':
         f.write(a['data'])
         f.close()
     except ServerNotFound:
-        print 'Error, server not found %s %d' % (js.host, js.port)
+        raise ServerNotFound('Error, server not found %s %d' % (js.host, js.port))
     except AuthError:
-        print 'Error, Authentification failed for %s/%s' % (js.user, js.pwd)
+        raise AuthError('Error, Authentification failed for %s/%s' % (js.user, js.pwd))
 
     try:
         envelop = js.run_report(uri='/reports/samples/AllAccounts',
@@ -300,11 +300,11 @@ if __name__ == '__main__':
         f.write(a['data'])
         f.close()
     except ServerNotFound:
-        print 'Error, server not found %s %d' % (js.host, js.port)
+        raise ServerNotFound('Error, server not found %s %d' % (js.host, js.port))
     except AuthError:
-        print 'Error, Authentification failed for %s/%s' % (js.user, js.pwd)
+        raise AuthError('Error, Authentification failed for %s/%s' % (js.user, js.pwd))
     except ServerError, e:
-        print str(e)
+        raise ServerError( str(e))
 
     try:
         envelop = js.run_report(uri='/reports/samples/AllAccounts',
@@ -314,11 +314,11 @@ if __name__ == '__main__':
         f.write(a['data'])
         f.close()
     except ServerNotFound:
-        print 'Error, server not found %s %d' % (js.host, js.port)
+        raise ServerNotFound( 'Error, server not found %s %d' % (js.host, js.port))
     except AuthError:
-        print 'Error, Authentification failed for %s/%s' % (js.user, js.pwd)
+        raise AuthError( 'Error, Authentification failed for %s/%s' % (js.user, js.pwd))
     except ServerError, e:
-        print str(e)
+        raise ServerError( str(e))
 
     # Check unknown format
     try:
@@ -329,9 +329,9 @@ if __name__ == '__main__':
         f.write(a['data'])
         f.close()
     except ServerNotFound:
-        print 'Error, server not found %s %d' % (js.host, js.port)
+        raise ServerNotFound( 'Error, server not found %s %d' % (js.host, js.port))
     except AuthError:
-        print 'Error, Authentification failed for %s/%s' % (js.user, js.pwd)
+        raise AuthError( 'Error, Authentification failed for %s/%s' % (js.user, js.pwd))
     except UnknownFormat as e:
         pass
 

--- a/jasper_server/obj_document.py
+++ b/jasper_server/obj_document.py
@@ -123,7 +123,7 @@ class jasper_document(orm.Model):
         # RML fields
         'rml_ir_actions_report_xml_id': fields.many2one('ir.actions.report.xml', string='Report to generate RML'),
         'rml_ir_actions_report_xml_name': fields.related('rml_ir_actions_report_xml_id', 'report_name', type="char", string='Report to generate RML'),
-
+        'error_text': fields.text('Errors') 
     }
 
     _sql_constraints = [('unique_number', 'unique(report_link_name)','The Report Link Name must be unique.')]

--- a/jasper_server/obj_document.py
+++ b/jasper_server/obj_document.py
@@ -322,6 +322,21 @@ class jasper_document(orm.Model):
 
         default['report_id'] = False
         default['name'] = doc.name + _(' (copy)')
+
+        new_yaml_object_ids = []
+        for yaml_object in doc.yaml_object_ids:
+            new_yaml_object_ids.append((4, self.pool.get('jasper.yaml_object').copy(cr, uid, yaml_object.id, default=None, context=context)))
+        new_param_ids = []
+        for param in doc.param_ids:
+            new_param_ids.append((4, self.pool.get('jasper.document.parameter').copy(cr, uid, param.id, default=None, context=context)))
+        new_label_ids = []
+        for label in doc.label_ids:
+            new_label_ids.append((4, self.pool.get('jasper.document.label').copy(cr, uid, label.id, default=None, context=context)))
+
+        default['yaml_object_ids'] = new_yaml_object_ids
+        default['param_ids'] = new_param_ids
+        default['label_ids'] = new_label_ids
+
         return super(jasper_document, self).copy(cr, uid, id, default,
                                                  context=context)
 

--- a/jasper_server/obj_document_view.xml
+++ b/jasper_server/obj_document_view.xml
@@ -288,6 +288,9 @@
                             <page string="Labels">
                                 <field name="label_ids" nolabel="1" />
                             </page>
+                            <page string="Errors">
+                            	<field name="error_text" nolabel="1" />
+                            </page>
                         </notebook>
                     </sheet>
                 </form>

--- a/jasper_server/obj_server.py
+++ b/jasper_server/obj_server.py
@@ -272,8 +272,16 @@ class JasperServer(orm.Model):
             xmlObject.set("name", yaml_object.name)
             xmlObject.set("model", yaml_object.model.name)
             for object in model_obj.browse(cr, user_id, model_ids, ctx):
-                xmlField = Element('container')                
-                xmlField.set("name", object.name)
+                xmlField = Element('container')    
+                
+                # take the field name if it exists in model and if name is not False
+                # else take the rec_name value if a rec_name was used
+                # else take simply the object id            
+                xmlField.set("name", object.name if 'name' in object._fields and object.name else
+                                model_obj.read(cr, uid, 
+                                               [object.id], 
+                                               [object._rec_name])[0][object._rec_name] if object._rec_name else
+                                str(object.id))
                 try:
                     self.generate_from_yaml(cr, user_id, xmlField, object, yaml.load(yaml_object.fields), context=ctx)
                 except:

--- a/jasper_server/obj_server.py
+++ b/jasper_server/obj_server.py
@@ -273,15 +273,20 @@ class JasperServer(orm.Model):
             xmlObject.set("model", yaml_object.model.name)
             for object in model_obj.browse(cr, user_id, model_ids, ctx):
                 xmlField = Element('container')    
-                
+
                 # take the field name if it exists in model and if name is not False
                 # else take the rec_name value if a rec_name was used
-                # else take simply the object id            
-                xmlField.set("name", object.name if 'name' in object._fields and object.name else
-                                model_obj.read(cr, uid, 
+                # else take simply the object id    
+                rec_name_value = model_obj.read(cr, uid, 
                                                [object.id], 
-                                               [object._rec_name])[0][object._rec_name] if object._rec_name else
-                                str(object.id))
+                                               [object._rec_name])[0][object._rec_name]
+
+                if 'name' in object._fields and object.name:
+                    xmlField.set("name", object.name)
+                elif object._rec_name and rec_name_value:
+                    xmlField.set("name", rec_name_value)
+                else:
+                    xmlField.set("name", str(object.id))
                 try:
                     self.generate_from_yaml(cr, user_id, xmlField, object, yaml.load(yaml_object.fields), context=ctx)
                 except:

--- a/jasper_server/obj_server.py
+++ b/jasper_server/obj_server.py
@@ -274,7 +274,10 @@ class JasperServer(orm.Model):
             for object in model_obj.browse(cr, user_id, model_ids, ctx):
                 xmlField = Element('container')                
                 xmlField.set("name", object.name)
-                self.generate_from_yaml(cr, user_id, xmlField, object, yaml.load(yaml_object.fields), context=ctx)
+                try:
+                    self.generate_from_yaml(cr, user_id, xmlField, object, yaml.load(yaml_object.fields), context=ctx)
+                except:
+                    raise
                 xmlObject.append(xmlField)
 
             root.append(xmlObject)

--- a/jasper_server/report/report_exception.py
+++ b/jasper_server/report/report_exception.py
@@ -30,6 +30,8 @@ class JasperException(Exception):
     def __init__(self, title='Error', message='Empty message'):
         self.title = title
         self.message = message
+        self.name = title
+        self.value = message
 
     def __str__(self):
         return '%s: %s' % (self.title, self.message)

--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -258,8 +258,8 @@ class Report(object):
         # If language is set in the jasper document we get it, otherwise language is by default American English 
         language = context.get('lang', 'en_US')
         if current_document.lang:
-            language = self._eval_lang(cur_obj, current_document)
-            if type(language) is not str:  # type is str if language is given directly as string 'de_DE' for instance
+            language = self._eval_lang(cur_obj, current_document)            
+            if isinstance(language, list):   # type is str if language is given directly as string 'de_DE' for instance
                 language = language[0][0] 
 
         # Check if we can launch this reports

--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -631,15 +631,15 @@ class Report(object):
                         ex = traceback.format_exception(type_, value_, traceback_)
 
                         #self.add_error_message(doc,e[0],e[1], context=context)
-                        if isinstance(e,list):
-                            ex_all = e[0]+' : ' + e[1] +'\n'
+                        if isinstance(e, list):
+                            ex_all = e[0] + ' : ' + e[1] + '\n'
                             for item in ex:
-                                ex_all = ex_all+item
-                            self.add_error_message(doc,e[0],ex_all, context=context)
-                            raise except_osv(e[0],e[1])
+                                ex_all = ex_all + item
+                            self.add_error_message(doc, e[0], ex_all, context=context)
+                            raise except_osv(e.name, e.value)
                         else:
-                            self.add_error_message(doc,e.title,e.message.message, context=context)
-                            raise except_osv(e.title,e.message.message)
+                            self.add_error_message(doc, e.name, e.value, context=context)
+                            raise except_osv(e.name, e.value)
                     one_check[doc.id] = True
                     all_xml.append(content)
         else:

--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -626,17 +626,20 @@ class Report(object):
                     try:
                         (content, duplicate) = self._jasper_execute(ex, doc, js, pdf_list, reload, ids, context=self.context)
                     except Exception as e:
-                        
+
                         type_, value_, traceback_ = sys.exc_info()
                         ex = traceback.format_exception(type_, value_, traceback_)
-                        
+
                         #self.add_error_message(doc,e[0],e[1], context=context)
-                        ex_all = e[0]+' : ' + e[1] +'\n'
-                        for item in ex:
-                            ex_all = ex_all+item
-                        self.add_error_message(doc,e[0],ex_all, context=context)
-                        
-                        raise except_osv(e[0],e[1])
+                        if isinstance(e,list):
+                            ex_all = e[0]+' : ' + e[1] +'\n'
+                            for item in ex:
+                                ex_all = ex_all+item
+                            self.add_error_message(doc,e[0],ex_all, context=context)
+                            raise except_osv(e[0],e[1])
+                        else:
+                            self.add_error_message(doc,e.title,e.message.message, context=context)
+                            raise except_osv(e.title,e.message.message)
                     one_check[doc.id] = True
                     all_xml.append(content)
         else:

--- a/jasper_server/report/report_soap.py
+++ b/jasper_server/report/report_soap.py
@@ -43,8 +43,6 @@ from xml.etree import ElementTree as et
 import sys
 import traceback
 
-from openerp import tools
-
 _logger = logging.getLogger('openerp.addons.jasper_server.report')
 
 # #

--- a/jasper_server/wizard/load_file.py
+++ b/jasper_server/wizard/load_file.py
@@ -38,7 +38,7 @@ class LoadFile(orm.TransientModel):
     }
 
     def import_file(self, cr, uid, ids, context=None):
-        print context
+        
         this = self.browse(cr, uid, ids[0], context=context)
         content = base64.decodestring(this.datafile)
         self.pool['jasper.document'].parse_jrxml(


### PR DESCRIPTION
querys and to extend the existing context.
Replace some messages printed by dialogs that are raised
Changed structure of XML file, so that it has a container for each
object within /data/object.
Now we can export XML for several items previously chosen or all of them
setting in domain of YAML object [].
Fixed bug with language so that now you can use the field language in
jasper document and set there the language of somo item of the object,
or directly the string with the code of the language.
