### PR TITLE
Non-stored computed fields created using the new API style are not

### DIFF
--- a/jasper_server/obj_server.py
+++ b/jasper_server/obj_server.py
@@ -295,7 +295,7 @@ class JasperServer(orm.Model):
                         self.generate_from_yaml(cr, uid, xmlField, object[fieldname], value, prefix + fieldname, context=context)
                 else:
                     # set element content
-                    xmlField.text = self._format_element(xmlField, object._model._all_columns[field].column._type, object[fieldname])
+                    xmlField.text = self._format_element(xmlField, object._model._fields[field].type, object[fieldname])
 
             else:
                 xmlField = Element(prefix + field)
@@ -303,7 +303,8 @@ class JasperServer(orm.Model):
                 # set element content
                 xmlField.text = ''
                 if object:
-                    xmlField.text = self._format_element(xmlField, object._model._all_columns[field].column._type, object[field])
+                    xmlField.text = self._format_element(xmlField, object._model._fields[field].type, object[field])
+
 
             root.append(xmlField)
         return


### PR DESCRIPTION
available in _columns and can only be inspected through _fields

Modifying code to have that into account and be able to get type of
non-stored computed fields in v8
