### PR TITLE
Adding boolean "Add Super Container" to Jasper Document.

### DIFF
--- a/jasper_server/obj_document.py
+++ b/jasper_server/obj_document.py
@@ -123,7 +123,8 @@ class jasper_document(orm.Model):
         # RML fields
         'rml_ir_actions_report_xml_id': fields.many2one('ir.actions.report.xml', string='Report to generate RML'),
         'rml_ir_actions_report_xml_name': fields.related('rml_ir_actions_report_xml_id', 'report_name', type="char", string='Report to generate RML'),
-        'error_text': fields.text('Errors') 
+        'error_text': fields.text('Errors'),
+        'add_super_container': fields.boolean('Add super container?', help="Use it to create a single report in which different objects act as lines, instead of merging a different report for each object (usual use case).")
     }
 
     _sql_constraints = [('unique_number', 'unique(report_link_name)','The Report Link Name must be unique.')]

--- a/jasper_server/obj_document_view.xml
+++ b/jasper_server/obj_document_view.xml
@@ -227,6 +227,7 @@
                                     <field name="attachment_use"/>
                                     <field name="debug" attr="{'invisible': [('mode','!=','yaml'),('mode','!=','rml')]"/>
                                     <field name="any_database"/>
+                                    <field name="add_super_container"/>
                                 </group>
                             </page>
                             <page string="Groups">


### PR DESCRIPTION
This allows to add a main container to gather other child containers, one per item.
This will allow to create a single report iterating over items as lines, instead of a different report per item.
To this end, when the flag is active, instead of generating PDF per each item and later merging different PDFs,
we create XML per each item, then merge the different XMLs with the main container, and finally generate a single PDF from the merged XML